### PR TITLE
Fix windows prohibited simbols

### DIFF
--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -263,13 +263,13 @@ func (transfer *TransferStructure) FillPiecesParted() {
 	}
 }
 
+// we can't use these symbols on Windows systems, but can use in *nix
+var prohibitedSymbols = regexp.MustCompilePOSIX(`[/:*?"<>|]`)
+
 func (transfer *TransferStructure) HandleSavePaths() {
 	// Original paths always ending with pathSeparator
 	// SubFolder or NoSubfolder never have ending pathSeparator
 	// qBtSavePath always has separator /, otherwise SavePath use os pathSeparator
-
-	// we can't use these symbols on windows systems, but can use in *nix
-	prohibitedSymbols := `/:*?"<>|`
 
 	if transfer.Magnet {
 		transfer.Fastresume.QBtContentLayout = "Original"
@@ -287,8 +287,8 @@ func (transfer *TransferStructure) HandleSavePaths() {
 
 		// transform windows prohibited symbols like libtorrent or utorrent do
 		if transfer.Opts.PathSeparator == `\` {
-			torrentName = helpers.ReplaceAllSymbols(torrentName, prohibitedSymbols, `_`)
-			torrentNameOriginal = helpers.ReplaceAllSymbols(torrentNameOriginal, prohibitedSymbols, `_`)
+			torrentName = prohibitedSymbols.ReplaceAllString(torrentName, `_`)
+			torrentNameOriginal = prohibitedSymbols.ReplaceAllString(torrentNameOriginal, `_`)
 		}
 		lastPathName := fileHelpers.Base(helpers.HandleCesu8(transfer.ResumeItem.Path))
 
@@ -368,9 +368,9 @@ func (transfer *TransferStructure) HandleSavePaths() {
 		if transfer.Opts.PathSeparator == `\` && transfer.Fastresume.MappedFiles != nil {
 			for index, mappedFile := range transfer.Fastresume.MappedFiles {
 				if fileHelpers.IsAbs(mappedFile) {
-					transfer.Fastresume.MappedFiles[index] = mappedFile[:2] + helpers.ReplaceAllSymbols(mappedFile[2:], prohibitedSymbols, `_`)
+					transfer.Fastresume.MappedFiles[index] = mappedFile[:2] + prohibitedSymbols.ReplaceAllString(mappedFile[2:], `_`)
 				} else {
-					transfer.Fastresume.MappedFiles[index] = helpers.ReplaceAllSymbols(mappedFile, prohibitedSymbols, `_`)
+					transfer.Fastresume.MappedFiles[index] = prohibitedSymbols.ReplaceAllString(mappedFile, `_`)
 				}
 			}
 		}

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -363,7 +363,11 @@ func (transfer *TransferStructure) HandleSavePaths() {
 		// transform windows prohibited symbols like libtorrent or utorrent do
 		if transfer.Opts.PathSeparator == `\` && transfer.Fastresume.MappedFiles != nil {
 			for index, mappedFile := range transfer.Fastresume.MappedFiles {
-				transfer.Fastresume.MappedFiles[index] = helpers.ReplaceAllSymbols(mappedFile, prohibitedSymbols, `_`)
+				if fileHelpers.IsAbs(mappedFile) {
+					transfer.Fastresume.MappedFiles[index] = mappedFile[:2] + helpers.ReplaceAllSymbols(mappedFile[2:], prohibitedSymbols, `_`)
+				} else {
+					transfer.Fastresume.MappedFiles[index] = helpers.ReplaceAllSymbols(mappedFile, prohibitedSymbols, `_`)
+				}
 			}
 		}
 	}

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -267,7 +267,10 @@ func (transfer *TransferStructure) HandleSavePaths() {
 	// Original paths always ending with pathSeparator
 	// SubFolder or NoSubfolder never have ending pathSeparator
 	// qBtSavePath always has separator /, otherwise SavePath use os pathSeparator
+
+	// we can't use these symbols on windows systems, but can use in *nix
 	prohibitedSymbols := `/:*?"<>|`
+
 	if transfer.Magnet {
 		transfer.Fastresume.QBtContentLayout = "Original"
 		transfer.Fastresume.QbtSavePath = fileHelpers.Normalize(helpers.HandleCesu8(transfer.ResumeItem.Path), "/")
@@ -360,6 +363,7 @@ func (transfer *TransferStructure) HandleSavePaths() {
 				transfer.Fastresume.QbtSavePath += `/`
 			}
 		}
+
 		// transform windows prohibited symbols like libtorrent or utorrent do
 		if transfer.Opts.PathSeparator == `\` && transfer.Fastresume.MappedFiles != nil {
 			for index, mappedFile := range transfer.Fastresume.MappedFiles {

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -267,6 +267,7 @@ func (transfer *TransferStructure) HandleSavePaths() {
 	// Original paths always ending with pathSeparator
 	// SubFolder or NoSubfolder never have ending pathSeparator
 	// qBtSavePath always has separator /, otherwise SavePath use os pathSeparator
+	prohibitedSymbols := `/:*?"<>|`
 	if transfer.Magnet {
 		transfer.Fastresume.QBtContentLayout = "Original"
 		transfer.Fastresume.QbtSavePath = fileHelpers.Normalize(helpers.HandleCesu8(transfer.ResumeItem.Path), "/")
@@ -279,6 +280,12 @@ func (transfer *TransferStructure) HandleSavePaths() {
 		} else {
 			torrentName = helpers.HandleCesu8(transfer.TorrentFile.Info.Name)
 			torrentNameOriginal = transfer.TorrentFile.Info.Name
+		}
+
+		// transform windows prohibited symbols like libtorrent or utorrent do
+		if transfer.Opts.PathSeparator == `\` {
+			torrentName = helpers.ReplaceAllSymbols(torrentName, prohibitedSymbols, `_`)
+			torrentNameOriginal = helpers.ReplaceAllSymbols(torrentNameOriginal, prohibitedSymbols, `_`)
 		}
 		lastPathName := fileHelpers.Base(helpers.HandleCesu8(transfer.ResumeItem.Path))
 
@@ -351,6 +358,12 @@ func (transfer *TransferStructure) HandleSavePaths() {
 			transfer.Fastresume.QbtSavePath = fileHelpers.CutLastPath(helpers.HandleCesu8(transfer.ResumeItem.Path), `/`)
 			if string(transfer.Fastresume.QbtSavePath[len(transfer.Fastresume.QbtSavePath)-1]) != `/` {
 				transfer.Fastresume.QbtSavePath += `/`
+			}
+		}
+		// transform windows prohibited symbols like libtorrent or utorrent do
+		if transfer.Opts.PathSeparator == `\` && transfer.Fastresume.MappedFiles != nil {
+			for index, mappedFile := range transfer.Fastresume.MappedFiles {
+				transfer.Fastresume.MappedFiles[index] = helpers.ReplaceAllSymbols(mappedFile, prohibitedSymbols, `_`)
 			}
 		}
 	}

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -1220,6 +1220,55 @@ func TestTransferStructure_HandleSavePaths(t *testing.T) {
 				Opts: &options.Opts{PathSeparator: `\`},
 			},
 		},
+		{
+			name: "035 Test torrent with windows folder (NoSubfolder) with prohibited symbols.",
+			newTransferStructure: &TransferStructure{
+				Fastresume: &qBittorrentStructures.QBittorrentFastresume{},
+				ResumeItem: &utorrentStructs.ResumeItem{Path: `D:\torrents\renamed test_torrent`},
+				TorrentFile: &torrentStructures.Torrent{
+					Info: &torrentStructures.TorrentInfo{
+						Name: "test_torrent",
+						Files: []*torrentStructures.TorrentFile{
+							&torrentStructures.TorrentFile{Path: []string{`#test | test [01]{1} [6K].jpg`}},
+							&torrentStructures.TorrentFile{Path: []string{`testdir1 collection`, `testdir2?`, `1.jpg`}},
+						},
+					},
+				},
+				Opts: &options.Opts{PathSeparator: `\`},
+			},
+			expected: &TransferStructure{
+				Fastresume: &qBittorrentStructures.QBittorrentFastresume{
+					QbtSavePath:      `D:/torrents/renamed test_torrent`,
+					SavePath:         `D:\torrents\renamed test_torrent`,
+					QBtContentLayout: "NoSubfolder",
+					MappedFiles: []string{
+						`#test _ test [01]{1} [6K].jpg`,
+						`testdir1 collection\testdir2_\1.jpg`,
+					},
+				},
+				Opts: &options.Opts{PathSeparator: `\`},
+			},
+		},
+		{
+			name: "036 Test torrent with windows single nofolder (original) path without replaces. With prohibited symbols",
+			newTransferStructure: &TransferStructure{
+				Fastresume: &qBittorrentStructures.QBittorrentFastresume{},
+				ResumeItem: &utorrentStructs.ResumeItem{Path: `D:\torrents\test_torrent.txt`},
+				TorrentFile: &torrentStructures.Torrent{
+					Info: &torrentStructures.TorrentInfo{
+						Name: `test|torrent.txt`,
+					},
+				},
+				Opts: &options.Opts{PathSeparator: `\`},
+			},
+			expected: &TransferStructure{
+				Fastresume: &qBittorrentStructures.QBittorrentFastresume{
+					QbtSavePath:      `D:/torrents/`,
+					SavePath:         `D:\torrents\`,
+					QBtContentLayout: "Original",
+				},
+			},
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -122,8 +123,6 @@ func HandleCesu8(str string) string {
 
 // ReplaceAllSymbols Replace all symbols in set to replacer
 func ReplaceAllSymbols(str string, set string, replacer string) string {
-	for _, n := range set {
-		str = strings.ReplaceAll(str, string(n), replacer)
-	}
-	return str
+	re := regexp.MustCompilePOSIX(`[` + regexp.QuoteMeta(set) + `]`)
+	return re.ReplaceAllString(str, replacer)
 }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -119,3 +119,11 @@ func HandleCesu8(str string) string {
 	}
 	return str
 }
+
+// ReplaceAllSymbols Replace all symbols in set to replacer
+func ReplaceAllSymbols(str string, set string, replacer string) string {
+	for _, n := range set {
+		str = strings.ReplaceAll(str, string(n), replacer)
+	}
+	return str
+}

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -57,10 +57,79 @@ func TestDecodeTorrentFile(t *testing.T) {
 		})
 	}
 }
+
 func TestEmojiCesu8(t *testing.T) {
 	cesu8 := "normal_text \xed\xa0\xbc\xed\xb6\x95 normal_text \xed\xa0\xbd\xed\xba\x9c.txt.torrent"
 	utf8 := "normal_text \xf0\x9f\x86\x95 normal_text \xf0\x9f\x9a\x9c.txt.torrent"
 	if utf8 != HandleCesu8(cesu8) {
 		t.Fatalf("Cesu8 to utf-8 transformation fail")
+	}
+}
+func TestReplaceAllSymbols(t *testing.T) {
+	type Case struct {
+		name     string
+		str      string
+		set      string
+		replacer string
+		expected string
+	}
+	cases := []Case{
+		{
+			name:     "001 one symbol",
+			str:      `qwerty`,
+			set:      `qry`,
+			replacer: `_`,
+			expected: `_we_t_`,
+		},
+		{
+			name:     "002 several replacer symbol",
+			str:      `qwerty`,
+			set:      `qry`,
+			replacer: `AAA`,
+			expected: `AAAweAAAtAAA`,
+		},
+		{
+			name:     "003 several replacer symbol that exists in str",
+			str:      `qwerty`,
+			set:      `qry`,
+			replacer: `qwerty`,
+			expected: `qwertyweqwertytqwerty`,
+		},
+		{
+			name:     "004 several replacer symbol that exists in str with special symbols",
+			str:      `[qwerty]`,
+			set:      `[qry]`,
+			replacer: `qwerty`,
+			expected: `qwertyqwertyweqwertytqwertyqwerty`,
+		},
+		{
+			name:     "005 several replacer symbol that exists in str with special symbols",
+			str:      `[qwerty]`,
+			set:      `[qry]`,
+			replacer: `[qwerty]`,
+			expected: `[qwerty][qwerty]we[qwerty]t[qwerty][qwerty]`,
+		},
+		{
+			name:     "006 emoji replace",
+			str:      `qwer🚎y`,
+			set:      `🚎`,
+			replacer: `_`,
+			expected: `qwer_y`,
+		},
+		{
+			name:     "006 two emoji replace",
+			str:      `qwer🚎y👍`,
+			set:      `🚎😊`,
+			replacer: `_`,
+			expected: `qwer_y👍`,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			replaced := ReplaceAllSymbols(testCase.str, testCase.set, testCase.replacer)
+			if replaced != testCase.expected {
+				t.Fatalf("Unexpected error:\nstr: %v set: %v replacer: %v\nGot: %v\nExpect %v\n", testCase.str, testCase.set, testCase.replacer, replaced, testCase.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
utorrent and qbittorrent replaces symbols like :?<>|/ to _ in names and filenames